### PR TITLE
Peer connect, drop peers on discovery interval

### DIFF
--- a/schema/json_build_config.json
+++ b/schema/json_build_config.json
@@ -102,6 +102,8 @@
         "structs.ControlMultipartySigningResponse",
         "structs.ControlMultipartyKeygenResponse",
         "structs.MultipartyAuthenticationRequest",
+        "structs.HealthRequest",
+        "structs.HealthResponse",
         "structs.VersionInfo"
       ]
     },

--- a/schema/src/structs.proto
+++ b/schema/src/structs.proto
@@ -707,6 +707,9 @@ message MultipartyAuthenticationRequest {
   string room_id = 2;
 }
 
+message HealthRequest {
+
+}
 
 message Request {
   optional GossipTransactionRequest gossip_transaction_request = 1;
@@ -727,6 +730,11 @@ message Request {
   optional string trace_id = 15;
   optional bool trace = 16;
   MultipartyAuthenticationRequest multiparty_authentication_request = 18;
+  HealthRequest health_request = 19;
+}
+
+message HealthResponse {
+
 }
 
 message Response {
@@ -746,6 +754,7 @@ message Response {
   UtxoConflictResolveResponse utxo_conflict_resolve_response = 10;
   QueryObservationProofResponse query_observation_proof_response = 11;
   HashSearchResponse hash_search_response = 12;
+  HealthResponse health_response = 14;
 }
 
 message QueryTransactionRequest {

--- a/src/core/discovery.rs
+++ b/src/core/discovery.rs
@@ -38,7 +38,8 @@ impl IntervalFold for Discovery {
 
         let mut req = structs::Request::default();
         req.get_peers_info_request = Some(GetPeersInfoRequest::default());
-        for r in self.relay.broadcast_async(peers.clone(), req, None).await? {
+        for (r, pk) in self.relay.broadcast_async(
+            peers.clone(), req, None).await?.iter().zip(peers.clone()) {
             match r {
                 Ok(o) => {
                     if let Some(o) = o.get_peers_info_response {
@@ -50,7 +51,8 @@ impl IntervalFold for Discovery {
                     }
                 }
                 Err(e) => {
-                    error!("Error in discovery: {}", e.json_or())
+                    error!("Error in discovery: {}", e.json_or());
+                    self.relay.ds.peer_store.remove_node(&pk).await?;
                 }
             }
         }

--- a/src/core/discovery.rs
+++ b/src/core/discovery.rs
@@ -42,12 +42,12 @@ impl IntervalFold for Discovery {
             peers.clone(), req, None).await?.iter().zip(peers.clone()) {
             match r {
                 Ok(o) => {
-                    if let Some(o) = o.get_peers_info_response {
+                    if let Some(o) = &o.get_peers_info_response {
                         // TODO: There's probably a better way to merge peer info here.
                         // Problem here is we might have slightly different but almost same based
                         // on observation ordinal
                         // o.peer_info
-                        results.extend(o.peer_info)
+                        results.extend(o.peer_info.clone())
                     }
                 }
                 Err(e) => {


### PR DESCRIPTION
Fixes issue associated with dead peers in data store, not ideal way to handle -- should mark for inactivity instead, but they'll be rediscovered for now.